### PR TITLE
Keep track of samples indices used for enrichment during enriching

### DIFF
--- a/examples/Basics/[5]enricher.ipynb
+++ b/examples/Basics/[5]enricher.ipynb
@@ -12,6 +12,7 @@
     "- Loading data and creating a layer.\n",
     "- Enriching it with average floors.\n",
     "- Previewing the enrichment setup.\n",
+    "- Using the debug feature to track sample indices.\n",
     "\n",
     "Let’s jazz things up! 🏙️"
    ]
@@ -79,11 +80,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Enriching the Layer\n",
+    "## Enriching the Layer with Debug Enabled\n",
     "\n",
-    "Now, let’s enrich the layer with the average number of floors per intersection. We’ll map the data, set up the enricher, and apply it.\n",
+    "Now, let’s enrich the layer with the average number of floors per intersection. We’ll map the data, set up the enricher with the debug feature enabled, and apply it.\n",
     "\n",
-    "More enriching workflows exist and would be available per the documentation. Hint: `count_by`\n"
+    "More enriching workflows exist and would be available per the documentation. Hint: `count_by`"
    ]
   },
   {
@@ -102,7 +103,7 @@
     "    output_column=\"nearest_intersection\",\n",
     ")\n",
     "\n",
-    "# Set up and apply enricher\n",
+    "# Set up and apply enricher with debug enabled\n",
     "enricher = (\n",
     "    mapper.enricher.with_data(  # From the enricher module\n",
     "        group_by=\"nearest_intersection\", values_from=\"numfloors\"\n",
@@ -110,11 +111,31 @@
     "    # Reading: With data grouped by the nearest intersection, and the values from the attribute numfloors\n",
     "    .aggregate_by(method=\"mean\", output_column=\"avg_floors\")\n",
     "    # Reading: Aggregate by using the mean and output this into the avg_floors new attribute of the urban layer\n",
+    "    .with_debug()  # Enable debug to add DEBUG_avg_floors column\n",
     "    .build()\n",
     ")\n",
     "enriched_layer = enricher.enrich(\n",
     "    mapped_data, layer\n",
     ")  # Data to use, Urban Layer to Enrich."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspecting the Enriched Layer with Debug Information\n",
+    "\n",
+    "Let’s take a look at the enriched layer, which now includes the `avg_floors` column and the `DEBUG_avg_floors` column with the list of indices from the input data used for each enrichment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preview the enriched layer with debug information\n",
+    "print(enriched_layer.layer[['avg_floors', 'DEBUG_avg_floors']].head(50))"
    ]
   },
   {
@@ -142,7 +163,7 @@
    "source": [
     "## Wrapping Up\n",
     "\n",
-    "Smashing work! 🎉 Your layer’s now enriched with average floors. Try visualising it next with `visualiser`."
+    "Smashing work! 🎉 Your layer’s now enriched with average floors and includes debug information to trace back to the original data. Try visualising it next with `visualiser`."
    ]
   },
   {

--- a/src/urban_mapper/modules/enricher/aggregator/abc_aggregator.py
+++ b/src/urban_mapper/modules/enricher/aggregator/abc_aggregator.py
@@ -7,10 +7,10 @@ from urban_mapper.utils import require_arguments_not_none
 @beartype
 class BaseAggregator(ABC):
     @abstractmethod
-    def _aggregate(self, input_dataframe: pd.DataFrame) -> pd.Series: ...
+    def _aggregate(self, input_dataframe: pd.DataFrame) -> pd.DataFrame: ...
 
     @require_arguments_not_none(
         "input_dataframe", error_msg="No input dataframe provided.", check_empty=True
     )
-    def aggregate(self, input_dataframe: pd.DataFrame) -> pd.Series:
+    def aggregate(self, input_dataframe: pd.DataFrame) -> pd.DataFrame:
         return self._aggregate(input_dataframe)

--- a/src/urban_mapper/modules/enricher/aggregator/aggregators/simple_aggregator.py
+++ b/src/urban_mapper/modules/enricher/aggregator/aggregators/simple_aggregator.py
@@ -27,7 +27,8 @@ class SimpleAggregator(BaseAggregator):
         self.value_column = value_column
         self.aggregation_function = aggregation_function
 
-    def _aggregate(self, input_dataframe: pd.DataFrame) -> pd.Series:
+    def _aggregate(self, input_dataframe: pd.DataFrame) -> pd.DataFrame:
         grouped = input_dataframe.groupby(self.group_by_column)
         aggregated = grouped[self.value_column].agg(self.aggregation_function)
-        return aggregated
+        indices = grouped.apply(lambda g: list(g.index))
+        return pd.DataFrame({"value": aggregated, "indices": indices})

--- a/src/urban_mapper/modules/enricher/enricher_factory.py
+++ b/src/urban_mapper/modules/enricher/enricher_factory.py
@@ -29,6 +29,10 @@ class EnricherFactory:
         self.config.with_data(*args, **kwargs)
         return self
 
+    def with_debug(self, debug: bool = True) -> "EnricherFactory":
+        self.config.debug = debug
+        return self
+
     def aggregate_by(self, *args, **kwargs) -> "EnricherFactory":
         self.config.aggregate_by(*args, **kwargs)
         return self

--- a/src/urban_mapper/modules/enricher/factory/config.py
+++ b/src/urban_mapper/modules/enricher/factory/config.py
@@ -12,6 +12,7 @@ class EnricherConfig:
         self.aggregator_config: Dict[str, Any] = {}
         self.enricher_type: str = "SingleAggregatorEnricher"
         self.enricher_config: Dict[str, Any] = {}
+        self.debug: bool = False
 
     def with_data(
         self,


### PR DESCRIPTION
Thank you to @soniacq for having this idea and requirements as part of her current project.  We now allow urban layer components (such as intersections, `roads`, `crosswalks`, `sidewalks`, and so on) to have an extra `DEBUG_pickup_count`, which shows which samples' indices from the original data were used to compute this enrichment, in addition to being enriched (nothing changed here) with a given new column such as `pickup_count` for roads in a taxi trips use case.

Consider this a technique to make the journey back to the original data following enrichment, sort of!

 Cheers!