### PR TITLE
feat(docs): add preview RDT link to doc

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,20 @@
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "UrbanMapper"


### PR DESCRIPTION
Example of how it would look like:

Pull Request's Documentation Preview: https://urbanmapper--46.org.readthedocs.build/en/46/

Cheers