### PR TITLE
Can @overturemaps  be used as an `Urban Layer`?

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -125,6 +125,14 @@ The `examples/` directory is organised into three main sections: `Basics/`, `End
     - **[2] Paris_Remarquable_Trees_Advanced_Pipeline.ipynb**: Explore the remarkable trees of Paris within its neighborhoods.
         - *What it does*: This notebook demonstrates how to load the remarkable trees dataset, create a neighborhoods layer, and enrich the neighborhoods with remarkable trees information. E.g., the count of them per neighborhood. Another one may be the circumference of the trees on average per neighborhood. Etc. As an extra, it LLM-compute a summary of why the trees are remarkable and what is the impact of them on the neighborhoods.
 
+    🗺️ **Overture Map & Urban Mapper?**
+
+    - **[1] overture_pipeline.ipynb**: Explore the Overture Map roads & buildings datasets using `UrbanMapper`.
+        - *What it does*: This notebook demonstrates how to load the Overture Map dataset, create a roads-based layer, and enrich the roads with Overture Map building counts. 
+
+    - **[2] overture_pipeline_advanced.ipynb**: Explore the Overture Map roads & buildings datasets using `UrbanMapper`.
+        - *What it does*: This notebook demonstrates how to load the Overture Map dataset, create a roads-based layer, and enrich the roads with Overture Map building counts, and plenty of other enrichers to explore the Overture buildings dataset.
+
 === "🔗 External Libraries Usage"
 
     `UrbanMapper` doesn’t work in isolation—it plays nicely with other powerful tools to make your user journey experience

--- a/examples/Study Cases/Overture/[1] overture_pipeline.ipynb
+++ b/examples/Study Cases/Overture/[1] overture_pipeline.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Can `UrbanMapper` be working with `Overture` Data –– Easy ?\n",
+    "\n",
+    "In a nutshell, yes 100%! However, can it be much better integrated? Of course, always!\n",
+    "\n",
+    "The following notebook showcases the `UrbanMapper` library to process and visualise `building counts` along `road segments` in `Manhattan, NYC` using data coming entirely from `Overture`. It follows a structured pipeline approach, including data loading, filtering, enrichment, and visualisation.\n",
+    "\n",
+    "https://overturemaps.org/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Prior all, let's simply initialise an `UrbanMapper` instance, setting the foundation for the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urban_mapper as um\n",
+    "import geopandas as gpd\n",
+    "from urban_mapper.pipeline import UrbanPipeline\n",
+    "\n",
+    "mapper = um.UrbanMapper()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Pre Requisites –– Data Preparation\n",
+    "\n",
+    "As the goal is to use `Overture` data we must ensure to have them prior all. To do so, follow the (1) https://docs.overturemaps.org/getting-data/overturemaps-py/ or (2) assuming you already have overture installed as in your general `pip` packages (in your CLI):\n",
+    "\n",
+    "```bash\n",
+    "overturemaps download --bbox=-74.257159,40.495992,-73.699215,40.915568 -f geojson --type=segment -o nyc_segments.geojson\n",
+    "overturemaps download --bbox=-74.016367,40.702726,-73.934212,40.821589 -f geoparquet --type=building -o manhattan_buildings.parquet\n",
+    "```\n",
+    "\n",
+    "This will, nothing more than downloading the right information (`roads` and `buildings`) at the right location from `Overture` to proceed with `Urban Mapper`.\n",
+    "\n",
+    "Next we simply need to make sure to clip the segments acquired from `Overture`, to `Manhattan` for computation's sake, but feel free to explore more!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.geometry import Polygon\n",
+    "\n",
+    "west, south, east, north = -74.016367, 40.702726, -73.934212, 40.821589\n",
+    "bbox = Polygon([(west, south), (east, south), (east, north), (west, north)])\n",
+    "\n",
+    "roads_gdf = gpd.read_file(\"<your_path>/nyc_segments.geojson\")\n",
+    "\n",
+    "if roads_gdf.crs != \"EPSG:4326\":\n",
+    "    roads_gdf = roads_gdf.to_crs(\"EPSG:4326\")\n",
+    "\n",
+    "road_subtype_gdf = roads_gdf[ # Keeping only the essential!\n",
+    "    (roads_gdf['subtype'] == 'road') & \n",
+    "    (roads_gdf['class'].isin(['motorway', 'residential', 'living_street', 'primary', 'secondary']))\n",
+    "]\n",
+    "\n",
+    "filtered_roads = gpd.clip(road_subtype_gdf, bbox)\n",
+    "filtered_roads.reset_index(drop=True, inplace=True)\n",
+    "\n",
+    "filtered_roads.to_file(\"manhattan_roads.geojson\", driver=\"GeoJSON\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "# Pre-Requisites –– Transforming the buildings into `Shapefile`\n",
+    "\n",
+    "The following step converts building data from a `parquet` file to a `shapefile`, as the `UrbanMapper API` currently requires `shapefile` input for `longitude` and `latitude` to be automatically inferred as later-on are heavily required.\n",
+    "\n",
+    "If the `parquet` buildings file was having `longitude` and `longitude` the following step would not be required.\n",
+    "\n",
+    "Meanwhile, note that the mechanism behind our `ShapefileLoader` will need to be repeated in the `Parquet`'s one and others to allow for input files to not have `longitude` and `latitude` by default in, yet, via `geometry` coordinates should automatically be inferred. Mechanism is present already, simply needs to be scaled to more primitives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_nyc_buildings = gpd.read_parquet(\"<your_path>/manhattan_buildings.parquet\")\n",
+    "tmp_nyc_buildings.to_file(\"./manhattan_buildings.shp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Loader`\n",
+    "\n",
+    "The `loader` component is defined to read the preprocessed building data from the shapefile. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = (\n",
+    "    mapper.loader\n",
+    "    .from_file(\"./manhattan_buildings.shp\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Urban Layer`\n",
+    "\n",
+    "The `urban layer` component uses the filtered `road segments`, mapping building coordinates to the nearest road. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urban_layer = (\n",
+    "    mapper.urban_layer\n",
+    "    .with_type(\"custom_urban_layer\")\n",
+    "    .from_file(\"./manhattan_roads.geojson\")\n",
+    "    .with_mapping(\n",
+    "        longitude_column=\"temporary_longitude\",\n",
+    "        latitude_column=\"temporary_latitude\",\n",
+    "        output_column=\"nearest_road\"\n",
+    "    )\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Imputer`\n",
+    "\n",
+    "The `imputer` fills in missing longitude and latitude values to ensure data integrity. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imputer = (\n",
+    "    mapper.imputer\n",
+    "    .with_type(\"SimpleGeoImputer\")\n",
+    "    .on_columns(\"temporary_longitude\", \"temporary_latitude\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Filter`\n",
+    "\n",
+    "The `filter` applies a bounding box to refine the dataset spatially, making sure no buildings from `Brooklyn` are being attached to a road around `Manhattan`. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter_step = (\n",
+    "    mapper.filter\n",
+    "    .with_type(\"BoundingBoxFilter\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Enricher`\n",
+    "\n",
+    "The following `enricher` **counts** `buildings` per `road segment`, providing the key analytical output. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "building_count = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\")\n",
+    "    .count_by(output_column=\"building_count\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Visualiser`\n",
+    "\n",
+    "The `visualiser` sets up a basic static matplotlib figure. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visualiser = (\n",
+    "    mapper.visual\n",
+    "    .with_type(\"Static\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Pipeline Assembly\n",
+    "\n",
+    "The pipeline combines all pre-instantiated components in a logical sequence for processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = UrbanPipeline([\n",
+    "    (\"loader\", loader),\n",
+    "    (\"urban_layer\", urban_layer),\n",
+    "    (\"impute\", imputer),\n",
+    "    (\"filter\", filter_step),\n",
+    "    (\"enrich_building_count\", building_count),\n",
+    "    (\"visualiser\", visualiser),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "## Pipeline Execution\n",
+    "\n",
+    "This step runs the pipeline, transforming the data and generating the enriched layer. Note that there is a nice animation during the pipeline execution for you to follow-up with what's going on!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapped_data, enriched_layer = pipeline.compose_transform()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "## Visualisation\n",
+    "\n",
+    "The enriched layer is visualised, showing building counts along road segments statically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pipeline.visualise([\n",
+    "    \"building_count\",\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "## Export Results\n",
+    "\n",
+    "Finally, the processed data is saved to a `JupyterGIS file` for future analysis in a collaborative-in-real-time manner.\n",
+    "\n",
+    "https://jupytergis.readthedocs.io/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.to_jgis(\n",
+    "    filepath=\"new_york_city_overture_easy_pipeline.JGIS\",\n",
+    "    urban_layer_name=\"NYC Overture Roads & Buildings – Easy Pipeline\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Study Cases/Overture/[2] overture_pipeline_advanced.ipynb
+++ b/examples/Study Cases/Overture/[2] overture_pipeline_advanced.ipynb
@@ -1,0 +1,480 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Can `UrbanMapper` be working with `Overture` Data –– Advanced ?\n",
+    "\n",
+    "In a nutshell, yes 100%! However, can it be much better integrated? Of course, always!\n",
+    "\n",
+    "The following notebook showcases the `UrbanMapper` library to process and visualise `building counts` among multiple other enrichments along `road segments` in `Manhattan, NYC` using data coming entirely from `Overture`. It follows a structured pipeline approach, including data loading, filtering, enrichment, and visualisation.\n",
+    "\n",
+    "https://overturemaps.org/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Prior all, let's simply initialise an `UrbanMapper` instance, setting the foundation for the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urban_mapper as um\n",
+    "import geopandas as gpd\n",
+    "from urban_mapper.pipeline import UrbanPipeline\n",
+    "\n",
+    "mapper = um.UrbanMapper()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Pre Requisites –– Data Preparation\n",
+    "\n",
+    "Make sure you went through the `overture_pipeline.py` easy mode to understand how to get the data and the right way.\n",
+    "\n",
+    "Cheers!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Loader`\n",
+    "\n",
+    "The `loader` component is defined to read the preprocessed building data from the shapefile. Make the primitive ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = (\n",
+    "    mapper.loader\n",
+    "    .from_file(\"./manhattan_buildings.shp\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Urban Layer`, `Imputer`, and `Filter`\n",
+    "\n",
+    "- **Urban Layer**: Loads road segments from `manhattan_roads.geojson` and sets up the mapping configuration to associate building data with the nearest road.\n",
+    "- **Imputer**: Uses `SimpleGeoImputer` to handle missing longitude and latitude values, ensuring all data points can be mapped.\n",
+    "- **Filter**: Applies a `BoundingBoxFilter` to retain only the data (buildings) within Manhattan’s spatial bounds.\n",
+    "\n",
+    "Here, this is making the primitives ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urban_layer = (\n",
+    "    mapper.urban_layer\n",
+    "    .with_type(\"custom_urban_layer\")\n",
+    "    .from_file(\"./manhattan_roads.geojson\")\n",
+    "    .with_mapping(\n",
+    "        longitude_column=\"temporary_longitude\",\n",
+    "        latitude_column=\"temporary_latitude\",\n",
+    "        output_column=\"nearest_road\"\n",
+    "    )\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "imputer = (\n",
+    "    mapper.imputer\n",
+    "    .with_type(\"SimpleGeoImputer\")\n",
+    "    .on_columns(\"temporary_longitude\", \"temporary_latitude\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "filter_step = (\n",
+    "    mapper.filter\n",
+    "    .with_type(\"BoundingBoxFilter\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Enrichers`\n",
+    "\n",
+    "Multiple `enrichers` are defined to compute various `building` characteristics per `road segment`:\n",
+    "\n",
+    "- [x] Building count\n",
+    "- [x] Proportion of multi-floor buildings\n",
+    "- [x] Average building height\n",
+    "- [x] Predominant facade color (as a name)\n",
+    "- [x] Predominant building class\n",
+    "- [x] Average number of floors\n",
+    "- [x] Proportion of underground buildings\n",
+    "- [x] Height variety (standard deviation)\n",
+    "- [x] Proportion of named buildings\n",
+    "\n",
+    "These enrichers provide a comprehensive analysis of the building landscape along each road segment.\n",
+    "\n",
+    "–––\n",
+    "\n",
+    "We first partially install a library needed throughout one of the enricher. Followed by defining all lambda functions to accurately explore the `buildings` dataset throughout the various enrichers next defined.\n",
+    "\n",
+    "Lastly, recall that here, this is making the primitives ready to be used throughout the `pipeline` later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv pip install colory # could be without uv depending on your environmnent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from colory.color import Color\n",
+    "\n",
+    "def proportion_multi_floor(series):\n",
+    "    if series.empty or series.isna().all():\n",
+    "        return 0.0\n",
+    "    multi_floor_count = (series > 1).sum()\n",
+    "    total_count = series.notna().sum()\n",
+    "    return multi_floor_count / total_count if total_count > 0 else 0.0\n",
+    "\n",
+    "def most_common_value(series):\n",
+    "    if series.empty or series.isna().all():\n",
+    "        return None\n",
+    "    mode = series.mode()\n",
+    "    return mode.iloc[0] if not mode.empty else None\n",
+    "\n",
+    "def proportion_underground(series):\n",
+    "    if series.empty or series.isna().all():\n",
+    "        return 0.0\n",
+    "    underground_count = series.sum()\n",
+    "    total_count = series.notna().sum()\n",
+    "    return underground_count / total_count if total_count > 0 else 0.0\n",
+    "\n",
+    "def proportion_named(series):\n",
+    "    if series.empty or series.isna().all():\n",
+    "        return 0.0\n",
+    "    named_count = series.notna().sum()\n",
+    "    total_count = series.notna().sum()\n",
+    "    return named_count / total_count if total_count > 0 else 0.0\n",
+    "\n",
+    "def hex_to_rgb(hex_color):\n",
+    "    hex_color = hex_color.lstrip('#')\n",
+    "    return np.array([int(hex_color[i:i+2], 16) for i in (0, 2, 4)])\n",
+    "\n",
+    "def rgb_to_hex(rgb):\n",
+    "    return '#{:02x}{:02x}{:02x}'.format(*rgb)\n",
+    "\n",
+    "def avg_color_name(series):\n",
+    "    valid_colors = [color for color in series if color and isinstance(color, str) and color.startswith('#')]\n",
+    "    if not valid_colors:\n",
+    "        return 'Unknown'\n",
+    "    rgb_values = [hex_to_rgb(color) for color in valid_colors]\n",
+    "    avg_rgb = np.mean(rgb_values, axis=0).astype(int)\n",
+    "    avg_hex = rgb_to_hex(avg_rgb)\n",
+    "    return Color(avg_hex, 'xkcd').name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "building_count = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\")\n",
+    "    .count_by(output_column=\"building_count\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "multi_floor = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"num_floors\")\n",
+    "    .aggregate_by(method=proportion_multi_floor, output_column=\"prop_multi_floor\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "avg_height = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"height\")\n",
+    "    .aggregate_by(method=\"mean\", output_column=\"avg_height\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "predom_color_name = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"facade_col\")\n",
+    "    .aggregate_by(method=avg_color_name, output_column=\"avg_facade_color_name\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "predom_class = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"class\")\n",
+    "    .aggregate_by(method=most_common_value, output_column=\"predom_building_class\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "avg_floors = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"num_floors\")\n",
+    "    .aggregate_by(method=\"mean\", output_column=\"avg_floors\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "undergr_prop = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"is_undergr\")\n",
+    "    .aggregate_by(method=proportion_underground, output_column=\"prop_underground\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "height_variety = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"height\")\n",
+    "    .aggregate_by(method=lambda x: x.std(), output_column=\"height_std_dev\")\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "named_prop = (\n",
+    "    mapper.enricher\n",
+    "    .with_data(group_by=\"nearest_road\", values_from=\"names\")\n",
+    "    .aggregate_by(method=proportion_named, output_column=\"prop_named_buildings\")\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Component Instantiation: `Visualiser`\n",
+    "\n",
+    "The visualiser is configured for an `interactive map` with a `dark theme`, displaying the following enriched columns in tooltips:\n",
+    "\n",
+    "- [x] Building count\n",
+    "- [x] Proportion of multi-floor buildings\n",
+    "- [x] Average building height\n",
+    "- [x] Predominant facade color name\n",
+    "- [x] Predominant building class\n",
+    "- [x] Average number of floors\n",
+    "- [x] Proportion of underground buildings\n",
+    "- [x] Height variety (standard deviation)\n",
+    "- [x] Proportion of named buildings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visualiser = (\n",
+    "    mapper.visual\n",
+    "    .with_type(\"Interactive\")\n",
+    "    .with_style({\n",
+    "            \"tiles\": \"CartoDB dark_matter\",\n",
+    "            \"tooltip\": [\n",
+    "                \"building_count\",\n",
+    "                \"prop_multi_floor\",\n",
+    "                \"avg_height\",\n",
+    "                \"avg_facade_color_name\",\n",
+    "                \"predom_building_class\",\n",
+    "                \"avg_floors\",\n",
+    "                \"prop_underground\",\n",
+    "                \"height_std_dev\",\n",
+    "                \"prop_named_buildings\"\n",
+    "            ],\n",
+    "            \"colorbar_text_color\": \"white\",\n",
+    "    })\n",
+    "    .build()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Pipeline Assembly\n",
+    "\n",
+    "The pipeline combines all pre-instantiated components in a logical sequence for processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = UrbanPipeline([\n",
+    "    (\"loader\", loader),\n",
+    "    (\"urban_layer\", urban_layer),\n",
+    "    (\"impute\", imputer),\n",
+    "    (\"filter\", filter_step),\n",
+    "    (\"enrich_building_count\", building_count),\n",
+    "    (\"enrich_multi_floor\", multi_floor),\n",
+    "    (\"enrich_avg_height\", avg_height),\n",
+    "    (\"enrich_predom_color\", predom_color_name),\n",
+    "    (\"enrich_predom_class\", predom_class),\n",
+    "    (\"enrich_avg_floors\", avg_floors),\n",
+    "    (\"enrich_undergr_prop\", undergr_prop),\n",
+    "    (\"enrich_height_variety\", height_variety),\n",
+    "    (\"enrich_named_prop\", named_prop),\n",
+    "    (\"visualiser\", visualiser),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Pipeline Execution\n",
+    "\n",
+    "This step runs the pipeline, transforming the data and generating the enriched layer. Note that there is a nice animation during the pipeline execution for you to follow-up with what's going on!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapped_data, enriched_layer = pipeline.compose_transform()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "## Visualisation\n",
+    "\n",
+    "The enriched layer is visualised interactively, displaying multiple building characteristics along road segments, including building counts, height metrics, and facade color names. This allows for an in-depth exploration of the data.\n",
+    "\n",
+    "Feel free to use the tiny widger appearing above the map to focus on a specific enriched column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pipeline.visualise([\n",
+    "    \"building_count\",\n",
+    "    \"prop_multi_floor\",\n",
+    "    \"avg_height\",\n",
+    "    \"avg_facade_color_name\",\n",
+    "    \"predom_building_class\",\n",
+    "    \"avg_floors\",\n",
+    "    \"prop_underground\",\n",
+    "    \"height_std_dev\",\n",
+    "    \"prop_named_buildings\"\n",
+    "])\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Export Results\n",
+    "\n",
+    "Finally, the processed data is saved to a `JupyterGIS file` for future analysis in a collaborative-in-real-time manner.\n",
+    "\n",
+    "https://jupytergis.readthedocs.io/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.to_jgis(\n",
+    "    filepath=\"new_york_city_overture_advanced_pipeline.JGIS\",\n",
+    "    urban_layer_name=\"NYC Overture Roads & Buildings –– Advanced Pipeline\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
We provide an example as to how to use @overturemaps roads segments, and enrich them with @overturemaps buildings in a pipeline-way !

However, IMHO this is not sufficient enough! A much smoother integration should be needed as a `from_overturemaps(.)` in the `urban layer` module and therefore added to: #51.

Thanks so so much to @MrPowers from @wherobots and the @apache Sedona community to have suggested me this tiny example and potential further thinking towards a smoother integration of @overturemaps throughout the `Urban Layer` internal module :)

Cheers!

<!-- readthedocs-preview UrbanMapper start -->
----
📚 Documentation preview 📚: https://UrbanMapper--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview UrbanMapper end -->