### PR TITLE
Update installation instructions to reflect PyPI availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
    <h3>Enrich Urban Layers Given Urban Datasets</h3>
    <p><i>with ease-of-use API and Sklearn-alike Shareable & Reproducible Urban Pipeline</i></p>
    <p>
+      <img src="https://img.shields.io/pypi/v/urban-mapper?label=Version&style=for-the-badge" alt="PyPI Version">
       <img src="https://img.shields.io/static/v1?label=Beartype&message=compliant&color=4CAF50&style=for-the-badge&logo=https://avatars.githubusercontent.com/u/63089855?s=48&v=4&logoColor=white" alt="Beartype compliant">
       <img src="https://img.shields.io/static/v1?label=UV&message=compliant&color=2196F3&style=for-the-badge&logo=UV&logoColor=white" alt="UV compliant">
       <img src="https://img.shields.io/static/v1?label=RUFF&message=compliant&color=9C27B0&style=for-the-badge&logo=RUFF&logoColor=white" alt="RUFF compliant">
@@ -47,111 +48,67 @@ urban proceed with enriching your urban layer of interests from **insights**  yo
 ---
 
 ## 🥐 Installation
+`UrbanMapper` is a Python package designed for urban spatial data analysis. Before you start, you’ll need to setup your environment and install the appropriate packages. `UrbanMapper` requires Python `3.10` or higher. 
 
-We *highly* recommend using `uv` for installation from source to avoid the hassle of `Conda` or other package managers.
-It is also the fastest known to date on the OSS market and manages dependencies seamlessly without manual environment
-activation (Biggest flex!). If you do not want to use `uv`, there are no issues, but we will cover it in the upcoming
-documentation – not as follows.
+For more detailed installation instructions, refer to the [UrbanMapper Documentation](https://urbanmapper.readthedocs.io/en/latest/getting-started/installation/).
 
-> [!TIP]
-> **UV's readings recommendations:**
-> - [Python Packaging in Rust](https://astral.sh/blog/uv)
-> - [A Year of UV](https://www.bitecode.dev/p/a-year-of-uv-pros-cons-and-should)
-> - [UV Is All You Need](https://dev.to/astrojuanlu/python-packaging-is-great-now-uv-is-all-you-need-4i2d)
-> - [State of the Art Python 2024](https://4zm.org/2024/10/28/state-of-the-art-python-in-2024.html)
-> - [Data Scientist, From School to Work](https://towardsdatascience.com/data-scientist-from-school-to-work-part-i/)
+### Virtual environment
 
-### Prerequisites
+You should install `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can set up your environment using [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), or a [virtual environment](https://docs.python.org/3/library/venv.html).
+Using ``uv`` is the recommended method due to its speed and seamless modern dependency management.
 
-- First, ensure `uv` is installed on your machine by
-following [these instructions](https://docs.astral.sh/uv/getting-started/installation/).
-
-- Second, make sure you install at least `python` 3.10+. If you are not sure:
-
+<strong>Using uv (Recommended)</strong>
 ```bash
+# Optional: install and pin a specific Python version
 uv python install 3.10
 uv python pin 3.10
+
+# Create and activate a virtual env using the pinned Python version
+uv venv
+source .venv/bin/activate
+
+# Install the package from PyPI
+uv pip install urban-mapper
+
+# Launch Jupyter Lab to explore `UrbanMapper`
+uv run --with jupyter jupyter lab
+
+# To exit the environment
+deactivate
 ```
-
-And you are ready to go! 🎉
-
-### Steps
-
-1. Clone the `UrbanMapper` repository:
-   ```bash
-   git clone git@github.com:VIDA-NYU/UrbanMapper.git
-   # git clone https://github.com/VIDA-NYU/UrbanMapper.git
-   cd UrbanMapper
-   ```
-2. Lock and sync dependencies with `uv`:
-   ```bash
-   uv lock
-   uv sync
-   ```
-3. (Recommended) Install Jupyter extensions for interactive visualisations requiring Jupyter widgets:
-   ```bash
-   uv run jupyter labextension install @jupyter-widgets/jupyterlab-manager
-   ```
-4. Launch Jupyter Lab to explore `UrbanMapper` (Way faster than running Jupyter without `uv`):
-   ```bash
-   uv run --with jupyter jupyter lab
-   ```
-
-Voila 🥐 ! We'd recommend you explore next the # `Getting Started with UrbanMapper` section to see how to use the tool.
-
 <details>
+<summary><strong>Using conda</strong></summary>
 
-<summary>
-🫣 Different ways to install UrbanMapper (e.g w/ pip)
-</summary>
+```bash
+# Create and activate a conda environment
+conda create -n umenv python=3.10
+conda activate umenv
 
-<br>
+# Install the package from PyPI
+pip install urban-mapper
 
-> **Note on Alternative Dependency Management Methods**
->
-> While we strongly recommend using `uv` for managing dependencies due to its superior speed and ease of use, 
-> alternative methods are available for those who prefer not to use `uv`. These alternatives are not as efficient, 
-> as they are slower and require more manual intervention.
->
-> Please be aware that the following assumptions are made for these alternative methods:
-> - You have `pip` installed.
-> - You are working within a virtual environment or a conda environment.
->
-> If you are not currently using a virtual or conda environment, we highly recommend setting one up to prevent 
-> potential conflicts and maintain a clean development workspace. For assistance, refer to the following resources:
-> - [Creating a Python virtual environment](https://docs.python.org/3/library/venv.html)
-> - [Managing conda environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
+# Launch Jupyter Lab to explore `UrbanMapper`
+jupyter lab
 
-1. Clone the `UrbanMapper` repository:
-   ```bash
-    git clone git@github.com:VIDA-NYU/UrbanMapper.git
-    # git clone https://github.com/VIDA-NYU/UrbanMapper.git
-    cd UrbanMapper
-   ```
-2. Install `UrbanMapper` dependencies using `pip`:
-   ```bash
-    pip install -r requirements.txt
-   ```
-   
-3. Install `UrbanMapper`:
-   ```bash
-    pip install -e ./UrbanMapper
-    # or if you ensure you are in your virtual environment, cd UrbanMapper && pip install -e .
-    # Note that -e means "editable" mode, which allows you to make changes to the code and see them reflected.
-    # If you don't want to use editable mode, you can just run pip install ./UrbanMapper
-    ```
-
-4. (Recommended) Install Jupyter extensions for interactive visualisations requiring Jupyter widgets:
-   ```bash
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager
-   ```
-
-5. Launch Jupyter Lab to explore `UrbanMapper`:
-   ```bash
-    jupyter lab
-   ```
-
+# To exit the environment
+conda deactivate
+```
 </details>
+
+### Pip
+
+The most straightforward way to install `UrbanMapper` is with pip (works in any environment):
+ ```bash
+ pip install urban-mapper
+ ```
+Launch Jupyter Lab to explore `UrbanMapper`:
+```bash
+jupyter lab
+```
+### Source
+Building `UrbanMapper` from source lets you make changes to the code base. To install from the source, refer to the [Project Setup Guide](../CONTRIBUTING.md/#project-setup-guide).
+
+---
 
 # 🗺️ Urban Layers Currently Supported
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@
 
 
 
-![UrbanMapper Cover](./docs/public/resources/urban_mapper_cover.png)
+![UrbanMapper Cover](https://i.imgur.com/hZ2XkrN.png)
 
 
 ___
 
 > [!IMPORTANT]
-> 1) Documentation is out ! Check it out [here](https://urbanmapper.readthedocs.io/en/latest/) 🚀
-> 3) We support [JupyterGIS](https://github.com/geojupyter/jupytergis) as a bridge to export your `Urban Pipeline` for collaborative exploration 🏂 Shout-out to [@mfisher87](https://github.com/mfisher87) for his tremendous help.
+> - 📣 `UrbanMapper` is on [PyPi](https://pypi.org/project/urban-mapper/)!
+> - 🚀 Documentation is out ! Check it out [here](https://urbanmapper.readthedocs.io/en/latest/) 
+> - 🤝 We support [JupyterGIS](https://github.com/geojupyter/jupytergis) following one of your `Urban Pipeline`'s analysis for collaborative in real-time exploration on Jupyter 🏂 Shout-out to [@mfisher87](https://github.com/mfisher87) and `JGIS` team for their tremendous help.
 
 ## 🌆 UrbanMapper –– In a Nutshell
 
@@ -48,65 +49,20 @@ urban proceed with enriching your urban layer of interests from **insights**  yo
 ---
 
 ## 🥐 Installation
-`UrbanMapper` is a Python package designed for urban spatial data analysis. Before you start, you’ll need to setup your environment and install the appropriate packages. `UrbanMapper` requires Python `3.10` or higher. 
 
-For more detailed installation instructions, refer to the [UrbanMapper Documentation](https://urbanmapper.readthedocs.io/en/latest/getting-started/installation/).
-
-### Virtual environment
-
-You should install `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can set up your environment using [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), or a [virtual environment](https://docs.python.org/3/library/venv.html).
-Using ``uv`` is the recommended method due to its speed and seamless modern dependency management.
-
-<strong>Using uv (Recommended)</strong>
-```bash
-# Optional: install and pin a specific Python version
-uv python install 3.10
-uv python pin 3.10
-
-# Create and activate a virtual env using the pinned Python version
-uv venv
-source .venv/bin/activate
-
-# Install the package from PyPI
-uv pip install urban-mapper
-
-# Launch Jupyter Lab to explore `UrbanMapper`
-uv run --with jupyter jupyter lab
-
-# To exit the environment
-deactivate
-```
-<details>
-<summary><strong>Using conda</strong></summary>
-
-```bash
-# Create and activate a conda environment
-conda create -n umenv python=3.10
-conda activate umenv
-
-# Install the package from PyPI
-pip install urban-mapper
-
-# Launch Jupyter Lab to explore `UrbanMapper`
-jupyter lab
-
-# To exit the environment
-conda deactivate
-```
-</details>
-
-### Pip
-
-The most straightforward way to install `UrbanMapper` is with pip (works in any environment):
+Install `UrbanMapper` via ``pip`` (works in any environment):
  ```bash
  pip install urban-mapper
  ```
-Launch Jupyter Lab to explore `UrbanMapper`:
+Then launch Jupyter Lab to explore `UrbanMapper`:
 ```bash
 jupyter lab
 ```
-### Source
-Building `UrbanMapper` from source lets you make changes to the code base. To install from the source, refer to the [Project Setup Guide](../CONTRIBUTING.md/#project-setup-guide).
+
+> [!TIP]
+> We recommend installing `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can find detailed instructions—including how to install within a virtual environment using [uv](https://docs.astral.sh/uv/getting-started/installation/), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) or from source—
+in the [UrbanMapper Installation Guide](https://urbanmapper.readthedocs.io/en/latest/getting-started/installation/).
+> 
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,42 +14,114 @@ your work is important!
 
 ---
 
-## 🛠️ Environment Setup
-
-Get started by setting up your development environment. We recommend `uv` for its speed, but `pip` or `conda` work too.
+## 🛠️ Project Setup Guide 
 
 ### Prerequisites
 
-- **Install `uv`**: Grab it from the [official guide](https://docs.astral.sh/uv/getting-started/installation/).
+- `UrbanMapper` requires Python `3.10` or higher.
+- Use ``uv`` (recommended), ``conda``, or ``venv`` to manage your project setup. Follow the steps below to install one of them.
 
-### Steps
+    === "uv (Recommended)"
 
-1. **Clone the Repo**:
+        - To install `uv`, follow the instructions on the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/).
+        - If you don’t have Python `3.10` or higher / you prefer to be sure, you can install and pin it using uv:
+        ```bash
+        uv python install 3.10
+        uv python pin 3.10
+        ```
+
+    === "conda"
+
+        - To install `conda`, follow the instructions on the [conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
+        - If you don’t have Python `3.10` or higher, you can create a new conda environment with the required version:
+        ```bash
+        conda create -n urbanmapper python=3.10
+        conda activate urbanmapper
+        ```
+
+    === "venv"
+
+        - Ensure you have Python `3.10` or higher installed. You can check your Python version with:
+        ```bash
+        python3 --version
+        ```
+        - To create a virtual environment, use Python's built-in `venv` module:
+        ```bash
+        python3 -m venv urbanmapper-env
+        source urbanmapper-env/bin/activate  # On macOS/Linux
+        urbanmapper-env\Scripts\activate     # On Windows
+        ```
+
+### Clone the Repo
    ```bash
    git clone git@github.com:VIDA-NYU/UrbanMapper.git
    cd UrbanMapper
    ```
 
-2. **Sync Dependencies**:
-   ```bash
-   uv lock
-   uv sync
-   ```
-   **Note**: If you encounter errors related to 'cairo' during dependency installation, see
-   the [Troubleshooting](#troubleshooting) section.
+### Environment Setup
 
-3. **(Optional) Add Jupyter Extensions** for visualizations:
-   ```bash
-   uv run jupyter labextension install @jupyter-widgets/jupyterlab-manager
-   ```
+Get started by setting up your development environment. We recommend `uv` for its speed, but `pip` or `conda` work too. Choose one of the following options:
 
-4. **Launch Jupyter Lab**:
-   ```bash
-   uv run --with jupyter jupyter lab
-   ```
+=== "Using uv (Recommended)"
 
-- **Config Note**: Check out `config.yaml` in `urban_mapper/` for pipeline schemas and mixin mappings. It’s optional for
-  basic setup but key for advanced tweaks.
+    1. **Lock and sync dependencies**:
+    ```bash
+    uv lock
+    uv sync
+    ```
+    **Note**: If you encounter errors related to 'cairo' during dependency installation, see the [Troubleshooting](#troubleshooting) section.
+    
+    2. **(Recommended) Install Jupyter extensions** for interactive visualisations requiring Jupyter widgets:
+    ```bash
+    uv run jupyter labextension install @jupyter-widgets/jupyterlab-manager
+    ```
+
+    3. **Launch Jupyter Lab** to explore `UrbanMapper` (faster than running Jupyter without uv):
+    ```bash
+    uv run --with jupyter jupyter lab
+    ```
+
+    !!! tip "UV's readings recommendations:"
+        - [Python Packaging in Rust](https://astral.sh/blog/uv)
+        - [A Year of UV](https://www.bitecode.dev/p/a-year-of-uv-pros-cons-and-should)
+        - [UV Is All You Need](https://dev.to/astrojuanlu/python-packaging-is-great-now-uv-is-all-you-need-4i2d)
+        - [State of the Art Python 2024](https://4zm.org/2024/10/28/state-of-the-art-python-in-2024.html)
+        - [Data Scientist, From School to Work](https://towardsdatascience.com/data-scientist-from-school-to-work-part-i/)
+
+=== "Using pip"
+
+    If you prefer not to use `uv`, you can install `UrbanMapper` using `pip`. This method is slower and requires more manual intervention.
+
+    **Assumptions**:
+
+    - You have `pip` installed.
+    - You are working within a virtual environment or a conda environment.
+    !!! note
+        If you are not using a virtual or conda environment, it is highly recommended to set one up to avoid conflicts. Refer to [Python's venv documentation](https://docs.python.org/3/library/venv.html) or [conda's environment management guide](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for assistance.
+
+    1. **Install dependencies**:
+    ```bash
+    pip install -r requirements.txt
+    ```
+    2. **Install `UrbanMapper`**:
+    ```bash
+    pip install -e ./UrbanMapper
+    # or if you ensure you are in your virtual environment, cd UrbanMapper && pip install -e .
+    ```
+    The `-e` flag installs `UrbanMapper` in editable mode, allowing changes to the code to be reflected immediately. If you don’t need this, use `pip install ./UrbanMapper` instead.
+        
+    3. **(Recommended) Install Jupyter extensions** for interactive visualisations:
+    ```bash
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager
+    ```
+
+    4. **Launch Jupyter Lab**:
+    ```bash
+    jupyter lab
+    ```
+
+### Config Note:
+Check out `config.yaml` in `urban_mapper/` for pipeline schemas and mixin mappings. It’s optional for basic setup but key for advanced tweaks.
 
 !!! tip "Alternative Tools"
     Prefer `pip` or `conda`? That’s fine—just note `uv` is our go-to for performance.
@@ -171,12 +243,11 @@ Pre-commit hooks enforce standards by running checks (like `ruff`) before commit
     class SimpleGeoImputer(GeoImputerBase):
         def _transform(self, input_geodataframe: gpd.GeoDataFrame, urban_layer) -> gpd.GeoDataFrame:
             # Impute logic here
-            return input_geodataframe
-        def preview(self, format: str = "ascii") -> str:
-            return f"Imputer: SimpleGeoImputer\n  Lat: {self.latitude_column}"
+            return input_geodataframe        def preview(rmat: s        r = "-> str::
+    s        r     return f"Imputer: Simpl:s        r     eGeoImputer\n  Lat: {self.la:titude_column}"
     ```
 
-    - Place in `urban_mapper/modules/imputer/imputers/`.
+    - Place: in `urban_mapper/modules/imputer/imputers/`.
     - Auto-detected.
 
 === "Filter"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,26 +4,26 @@
 
 --- 
 
-## Virtual environment
+## ➡️ Via Virtual environment
 
-You should install `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can set up your environment using [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), or a [virtual environment](https://docs.python.org/3/library/venv.html).
+We recommend you to install `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can set up your environment using [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), or a [virtual environment](https://docs.python.org/3/library/venv.html).
 
 === "Using uv (Recommended)"
 
     ```bash
-    # Optional: install and pin a specific Python version
-    uv python install 3.10
-    uv python pin 3.10
-
-    # Create and activate a virtual environment using the pinned Python version
-    uv venv
-    source .venv/bin/activate
-
     # Install the package from PyPI
-    uv pip install urban-mapper
+    uv add urban-mapper
    
     # Launch Jupyter Lab to explore `UrbanMapper` (faster than running Jupyter without uv)
     uv run --with jupyter jupyter lab
+    ```
+    *Optional: Get into your UV's venv despite not being necessary / recommended by UV*
+
+    ```bash
+    #Create and activate a virtual environment using the pinned Python version
+    uv venv
+    source .venv/bin/activate
+    jupyter lab
 
     # To exit the environment
     deactivate
@@ -47,7 +47,7 @@ You should install `UrbanMapper` in a virtual environment to keep things tidy an
     ```
 ---
 
-## Pip
+## ➡️ Via `Pip`
 
 The most straightforward way to install `UrbanMapper` is with pip (works in any environment):
  ```bash
@@ -59,12 +59,12 @@ jupyter lab
 ```
 ---
 
-## Source
+## ➡️ From Source (Developer)
 Building `UrbanMapper` from source lets you make changes to the code base. To install from the source, refer to the [Project Setup Guide](../CONTRIBUTING.md/#project-setup-guide).
 
 ---
 
-## Conclusion
+## 🚀 Conclusion
 
 Well done! You’ve just installed `UrbanMapper`. Ready to take it further? 
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,126 +1,72 @@
 # 🥐 Welcome to the Installation guide!
 
-!!! important "Installation Is From Source, Soon To Be Available From PyPI"
-    For the time being, `UrbanMapper` is only available from source. We are working on making it available from PyPI 
-    soon. The complexity is due to the fact that `UrbanMapper` is meant to be changing a very lot in the coming weeks,
-    and we want to make sure that the PyPI version is stable and well-tested before releasing it. Stay tuned for updates!
-    In the meantime, you can install it from source using the instructions below and no worries! It is very fast!
+`UrbanMapper` is a Python package designed for urban spatial data analysis. Before you start, you’ll need to setup your environment and install the appropriate packages. `UrbanMapper` requires Python `3.10` or higher.
 
-`UrbanMapper` is a Python package designed for urban spatial data analysis. This guide provides instructions for
-installing `UrbanMapper`, with a focus on using [uv](https://github.com/astral-sh/uv) for efficient dependency management.
-`UrbanMapper` requires Python `3.10` or higher.
+--- 
 
----
+## Virtual environment
 
-## Prerequisites
-
-Before installing `UrbanMapper`, ensure you have the following:
-
-- **Python `3.10` or higher**
-- **uv** (recommended for installation from source)
-
-To install `uv`, follow the instructions on
-the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/).
-
-If you don’t have Python `3.10` or higher / you prefer to be sure, you can install and pin it using uv:
-
-```bash
-uv python install 3.10
-uv python pin 3.10
-```
-
----
-
-## Installation
-
-To install `UrbanMapper`, start by cloning the repository:
-
-```bash
-git clone git@github.com:VIDA-NYU/UrbanMapper.git
-# or
-# git clone https://github.com/VIDA-NYU/UrbanMapper.git
-cd `UrbanMapper`
-```
-
-Then, choose your installation method:
+You should install `UrbanMapper` in a virtual environment to keep things tidy and avoid dependency conflicts. You can set up your environment using [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended), [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), or a [virtual environment](https://docs.python.org/3/library/venv.html).
 
 === "Using uv (Recommended)"
 
-    ![UV Proof](https://github.com/astral-sh/uv/assets/1309177/03aa9163-1c79-4a87-a31d-7a9311ed9310#only-dark)
-
-    !!! tip "UV's readings recommendations:"
-        - [Python Packaging in Rust](https://astral.sh/blog/uv)
-        - [A Year of UV](https://www.bitecode.dev/p/a-year-of-uv-pros-cons-and-should)
-        - [UV Is All You Need](https://dev.to/astrojuanlu/python-packaging-is-great-now-uv-is-all-you-need-4i2d)
-        - [State of the Art Python 2024](https://4zm.org/2024/10/28/state-of-the-art-python-in-2024.html)
-        - [Data Scientist, From School to Work](https://towardsdatascience.com/data-scientist-from-school-to-work-part-i/)
-
-    Using `uv` is the recommended method for installing `UrbanMapper` from source due to its speed and seamless modern dependency management. Follow these steps:
-
-    1. **Lock and sync dependencies**:
-
     ```bash
-    uv lock
-    uv sync
-    ```
+    # Optional: install and pin a specific Python version
+    uv python install 3.10
+    uv python pin 3.10
 
-    2. **(Recommended) Install Jupyter extensions** for interactive visualisations requiring Jupyter widgets:
+    # Create and activate a virtual environment using the pinned Python version
+    uv venv
+    source .venv/bin/activate
 
-    ```bash
-    uv run jupyter labextension install @jupyter-widgets/jupyterlab-manager
-    ```
-
-    3. **Launch Jupyter Lab** to explore `UrbanMapper` (faster than running Jupyter without uv):
-
-    ```bash
+    # Install the package from PyPI
+    uv pip install urban-mapper
+   
+    # Launch Jupyter Lab to explore `UrbanMapper` (faster than running Jupyter without uv)
     uv run --with jupyter jupyter lab
+
+    # To exit the environment
+    deactivate
     ```
 
-=== "Using pip"
-
-    If you prefer not to use `uv`, you can install `UrbanMapper` using `pip`. This method is slower and requires more manual intervention.
-
-    **Assumptions**:
-
-    - You have `pip` installed.
-    - You are working within a virtual environment or a conda environment.
-
-    !!! note
-        If you are not using a virtual or conda environment, it is highly recommended to set one up to avoid conflicts. Refer to [Python's venv documentation](https://docs.python.org/3/library/venv.html) or [conda's environment management guide](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for assistance.
-
-    1. **Install dependencies**:
+=== "Using conda"
 
     ```bash
-    pip install -r requirements.txt
-    ```
+    # Create and activate a conda environment
+    conda create -n umenv python=3.10
+    conda activate umenv
 
-    2. **Install `UrbanMapper`**:
+    # Install the package from PyPI
+    pip install urban-mapper
 
-    ```bash
-    pip install -e ./UrbanMapper
-    # or if you ensure you are in your virtual environment, cd UrbanMapper && pip install -e .
-    ```
-
-    !!! tip
-        The `-e` flag installs `UrbanMapper` in editable mode, allowing changes to the code to be reflected immediately. If you don’t need this, use `pip install ./UrbanMapper` instead.
-
-    3. **(Recommended) Install Jupyter extensions** for interactive visualisations:
-
-    ```bash
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager
-    ```
-
-    4. **Launch Jupyter Lab**:
-
-    ```bash
+    # Launch Jupyter Lab to explore `UrbanMapper`
     jupyter lab
+
+    # To exit the environment
+    conda deactivate
     ```
+---
+
+## Pip
+
+The most straightforward way to install `UrbanMapper` is with pip (works in any environment):
+ ```bash
+ pip install urban-mapper
+ ```
+Launch Jupyter Lab to explore `UrbanMapper`:
+```bash
+jupyter lab
+```
+---
+
+## Source
+Building `UrbanMapper` from source lets you make changes to the code base. To install from the source, refer to the [Project Setup Guide](../CONTRIBUTING.md/#project-setup-guide).
 
 ---
 
 ## Conclusion
 
-Well done! You’ve just downloaded and installed `UrbanMapper`. Ready to take it further? 
+Well done! You’ve just installed `UrbanMapper`. Ready to take it further? 
 
 Head over to the [# Getting Started Step by Step](quick-start_step_by_step.md) section for a step-by-step guide on how 
 to use `UrbanMapper` for urban spatial data analysis.


### PR DESCRIPTION
- Revised installation steps in README.md, CONTRIBUTING.md, and the installation guide to reflect UrbanMapper's availability on PyPI, including clearer environment setup instructions.
- Added a dynamic PyPI version badge to README.md to highlight pip-installable support.

<!-- readthedocs-preview UrbanMapper start -->
----
📚 Documentation preview 📚: https://UrbanMapper--57.org.readthedocs.build/en/57/

<!-- readthedocs-preview UrbanMapper end -->