### PR TITLE
refactor(docs): add Urban Mapper MCP links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ___
 
 > [!IMPORTANT]
-> - 📹 `UrbanMapper` Introductory Video 👉 https://www.youtube.com/watch?v=QUmfvda_z2U 👈
+> - 📹 `UrbanMapper` got its first Model Context Protocol (MCP) 👉https://www.youtube.com/watch?v=6gLkmKevj8Y 👈
 > - 🤝 We support [JupyterGIS](https://github.com/geojupyter/jupytergis) following one of your `Urban Pipeline`'s
     analysis for collaborative in real-time exploration on Jupyter 🏂 Shout-out
     to [@mfisher87](https://github.com/mfisher87) and `JGIS` team for their tremendous help.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,8 @@ See a trailer-style video below to get a quick overview of `UrbanMapper` and its
 <iframe width="660" height="415" src="https://www.youtube-nocookie.com/embed/QUmfvda_z2U?si=nXKwC4_LA1C99ZR_&amp;controls=0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
+---
+
 ## `Urban Layers` Currently Supported
 
 `UrbanMapper` currently supports the following `urban layers`:
@@ -174,3 +176,4 @@ practical use cases showcases its capabilities in `transportation`, `safety`, `e
   pipeline.
 - [Urban Mapper's Examples](./EXAMPLES.md): Explore the `examples/` interactively via Jupyter notebooks.
 - [API Reference](api/loaders.md): Complete API documentation
+- [Urban Mapper's Official Model Context Protocol (MCP) — "Control Your Urban Analysis with LLMs"](https://mcpstack.readthedocs.io/en/latest/tutorials/urbanmapper-jupyter/)


### PR DESCRIPTION
Hey folks! Just added the links towards the Model Context Protocol (MCP) for Urban Mapper I just released!

Hope we can swipe this one fast :)

Cheers

<!-- readthedocs-preview UrbanMapper start -->
----
📚 Documentation preview 📚: https://UrbanMapper--75.org.readthedocs.build/en/75/

<!-- readthedocs-preview UrbanMapper end -->