### PR TITLE
fix(enricher): Using wrong configuration when many enrichers exist

### DIFF
--- a/src/urban_mapper/modules/enricher/enricher_factory.py
+++ b/src/urban_mapper/modules/enricher/enricher_factory.py
@@ -16,6 +16,7 @@ import inspect
 import pkgutil
 from pathlib import Path
 from thefuzz import process
+import copy
 
 
 @beartype
@@ -303,7 +304,7 @@ class EnricherFactory:
         self._instance = enricher_class(
             aggregator=aggregator,
             output_column=self.config.enricher_config["output_column"],
-            config=self.config,
+            config=copy.deepcopy(self.config),
         )
         if self._preview:
             self.preview(format=self._preview["format"])


### PR DESCRIPTION
`EnricherFactory` feeds enrichers with the same `config` reference, which causes wrong functioning.
For example, if an `UrbanPipeline` has more than one `loader` and more than one `enricher`, all the enrichers will share the same configuration - the last one defined in the `UrbanPipeline`. 

With the present modification, `EnricherFactory` sends a copy of its internal configuration to each `enricher`. This way, each `enricher` has a different configuration.

<!-- readthedocs-preview UrbanMapper start -->
----
📚 Documentation preview 📚: https://UrbanMapper--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview UrbanMapper end -->