### PR TITLE
`with_columns` cannot be stacked

### DIFF
--- a/test/urban_mapper/modules/loader/test_loader_factory.py
+++ b/test/urban_mapper/modules/loader/test_loader_factory.py
@@ -13,6 +13,14 @@ class TestLoaderFactory:
     hugginface_path = "oscur/NYC_speed_humps"
     number_of_rows = 1000
 
+    def test_with_columns_called_twice_raises_value_error(self):
+        loader_factory = self.loader.from_file(self.csv_path).with_columns(
+            longitude_column="longitude", latitude_column="latitude"
+        )
+
+        with pytest.raises(ValueError, match="with_columns has already been configured"):
+            loader_factory.with_columns(geometry_column="the_geom")
+
     def test_from_csv_file(self):
         """
         Lat/Long columns


### PR DESCRIPTION
Hi @fabiofelix !

Hope all is well. I managed to solve finally #44 ! I believe, given your recent great additions of multi-loaders and enrichers, we here simply needed to enforce so that no multi-with-columns is being instantiated to avoid confusion with users.

Let me know if you want me to make any changes!

If you want to see the changes of this PR only for the time begin: [click here
](https://github.com/VIDA-NYU/UrbanMapper/pull/83/commits/23e0f1e285ba8c1f03d88dbb838bce53af888132)
Solving #44 !

> [!WARNING]
> Please wait for #82 to be merged prior merging this one! I'll just have to quickly rebase with `main` to be up to date and good!

Cheeers

<!-- readthedocs-preview UrbanMapper start -->
----
📚 Documentation preview 📚: https://UrbanMapper--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview UrbanMapper end -->